### PR TITLE
Revert "Update basic.py"

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -189,8 +189,6 @@ class Basic(with_metaclass(ManagedProperties)):
             r = Basic(*r) if isinstance(r, frozenset) else r
             if isinstance(l, Basic):
                 c = l.compare(r)
-            elif l is None or r is None:                    
-                c = (l is not None) - (r is not None)
             else:
                 c = (l > r) - (l < r)
             if c:


### PR DESCRIPTION
Reverts ajcouvre/sympy#1

I'm not sure if I should have made that change (it was listed in the easy to fix and i was doing so for google summer of code applictions). If it is incorrect, please use this to correc it. It was only adding two lines of code (an elif statement after line 190 in basic.py) 
